### PR TITLE
Support methods and properties defined in extensions of other modules

### DIFF
--- a/Sources/RestrictCallCore/Extension/IndexStoreSymbol+.swift
+++ b/Sources/RestrictCallCore/Extension/IndexStoreSymbol+.swift
@@ -34,6 +34,7 @@ extension IndexStoreSymbol {
         if demangledName.matches(pattern: target.demangledNamePattern) {
             return true
         }
+
         let prefix = [target.module, target.type].compactMap(\.self).joined(separator: ".")
         if let name,
            !prefix.isEmpty,
@@ -42,6 +43,14 @@ extension IndexStoreSymbol {
         {
             return true
         }
+
+        if let name,
+           let targetModule = target.module,
+           demangledName.hasPrefix("(extension in \(targetModule))"),
+           name.matches(pattern: target.name) {
+            return true
+        }
+
         return false
     }
 }


### PR DESCRIPTION
```
$SSS10FoundationE4data8encodingSSSgAA4DataVh_SSAAE8EncodingVtcfc
```

```
(extension in Foundation):Swift.String.init(data: __shared Foundation.Data, encoding: (extension in Foundation):Swift.String.Encoding) -> Swift.Optional<Swift.String>
```

```yml
targets
  - reportType: error
    module: "Foundation"
    type: "String"
    name: "init\\(data:encoding:\\)"
```