### PR TITLE
Fix matching of static/class members declared with a leading static in demangled names

### DIFF
--- a/Sources/RestrictCallCore/Extension/IndexStoreSymbol+.swift
+++ b/Sources/RestrictCallCore/Extension/IndexStoreSymbol+.swift
@@ -36,9 +36,10 @@ extension IndexStoreSymbol {
         }
 
         let prefix = [target.module, target.type].compactMap(\.self).joined(separator: ".")
+        let normalizedName = demangledName.strippingStaticPrefix()
         if let name,
            !prefix.isEmpty,
-           demangledName.hasPrefix(prefix),
+           normalizedName.hasPrefix(prefix),
            name.matches(pattern: target.name)
         {
             return true
@@ -46,7 +47,7 @@ extension IndexStoreSymbol {
 
         if let name,
            let targetModule = target.module,
-           demangledName.hasPrefix("(extension in \(targetModule))"),
+           normalizedName.hasPrefix("(extension in \(targetModule))"),
            name.matches(pattern: target.name) {
             return true
         }

--- a/Sources/RestrictCallCore/Extension/String+.swift
+++ b/Sources/RestrictCallCore/Extension/String+.swift
@@ -11,3 +11,10 @@ extension String {
         self.range(of: pattern, options: .regularExpression) != nil
     }
 }
+
+extension String {
+    package func strippingStaticPrefix() -> String {
+        guard hasPrefix("static ") else { return self }
+        return String(dropFirst("static ".count))
+    }
+}


### PR DESCRIPTION
### Summary

Rules targeting **type-level properties** (e.g. `SwiftUI.Color.black`) were silently not matched, even though the equivalent rule for an instance member (e.g. `Foundation.URL.path`) worked. This PR makes type-level members match the same way instance members do.

### Reproduction

Given a rule:

```yaml
targets:
  - module: "SwiftUI"
    type: "Color"
    name: "black$"
```

and code:

```swift
let a = Color.black       // explicit
consumeColor(.black)      // inferred, no "Color" token in source
```

`restrict-call` reports **nothing**, while `Foundation.URL.path` with `name: "path$"` (the pattern used in the sample config) is reported correctly.

### Root cause

For a type-level member the occurrence that carries the `.call` role is the getter, and its demangled name is prefixed with a declaration modifier:

```
static SwiftUI.Color.black.getter : SwiftUI.Color
└────┘
 breaks matching
```

In `IndexStoreSymbol.matches(target:)` the type is identified with:

```swift
demangledName.hasPrefix(prefix)   // prefix == "SwiftUI.Color"
```

The leading `static ` makes this `hasPrefix` check fail, so the fallback branch that would otherwise match `name` against the pattern is never reached. Instance members are not affected because their demangled names have no such prefix (`Foundation.URL.path.getter : ...`), which is why `URL.path` already worked.

### Fix

Strip the leading `static ` before the prefix check, so type-level members are normalized to the same shape as instance members. (`class` members are demangled with the same `static ` keyword, so a single case covers `static`/`class` properties and methods.)

```swift
package func strippingStaticPrefix() -> String {
    guard hasPrefix("static ") else { return self }
    return String(dropFirst("static ".count))
}
```

The normalization is applied only to the `hasPrefix` branches; the full-pattern branch is left untouched, so no previously matching input changes behavior.

### Verification

Tested with an executable target that uses all four type-level member kinds plus instance-member controls, and inspected the generated IndexStore.

| member kind | rule `name` | before | after |
|---|---|:---:|:---:|
| `static var` | `staticProp$` | ✗ | ✓ |
| `class var` | `classProp$` | ✗ | ✓ |
| `static func` | `staticMethod` | ✓ | ✓ |
| `class func` | `classMethod` | ✓ | ✓ |
| `SwiftUI.Color.black` | `black$` | ✗ | ✓ |
| `Foundation.URL.init(string:)` (regression) | `init\(string:\)` | ✓ | ✓ |

- Static/class **properties** with an anchored pattern were the actual gap.
- Static/class **methods** already matched (their name is not at the end of the demangled string, so the unanchored full-pattern branch caught them); they are included to confirm no regression.
- Instance members and unrelated members (`Color.red`) are not flagged.

### Notes / follow-up (out of scope for this PR)

Matching against the demangled (human-readable) name is inherently sensitive to formatting such as the `static ` prefix, the ` .getter : Type` suffix, and constrained-extension forms (`where Self == ...`). A more robust long-term approach would be to match against the structured USR components (module / type / member / kind, all encoded in the USR and available at the call site) instead of the rendered string. Happy to open a separate issue for that if it's of interest.
